### PR TITLE
Update Project.toml [compat] for HDF5 v0.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MCMCChainsStorage"
 uuid = "51a256e2-afd8-4c38-88d8-a98ba8ad53ca"
 authors = ["Will M. Farr <wfarr@flatironinstitute.org>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
@@ -10,5 +10,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
-HDF5 = "0.16"
+HDF5 = "0.16, 0.17"
 MCMCChains = "4, 5, 6"


### PR DESCRIPTION
- updated [compat] to add HDF5 v0.17
- bump MCMCChainsStorage to v0.1.4