### PR TITLE
add `MCMCChains` version 7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,19 @@
 name = "MCMCChainsStorage"
 uuid = "51a256e2-afd8-4c38-88d8-a98ba8ad53ca"
 authors = ["Will M. Farr <wfarr@flatironinstitute.org>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
 HDF5 = "0.16, 0.17"
-MCMCChains = "4, 5, 6"
+MCMCChains = "4, 5, 6, 7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]


### PR DESCRIPTION
also moved `Test` into extras rather than as a dependency, and bumped version to 0.1.5.

Tests all pass locally.